### PR TITLE
Correct usage of +1 lambdas in the documentation.

### DIFF
--- a/src/Accessors.elm
+++ b/src/Accessors.elm
@@ -95,7 +95,7 @@ set accessor value s =
 and it returns the data structure, with the accessible field changed by applying
 the function to the existing value.
 ```
-over (foo << qux) (+1) myRecord
+over (foo << qux) ((+) 1) myRecord
 ```
 -}
 over : (Relation sub sub sub -> Relation super sub wrap)

--- a/src/Accessors/Library.elm
+++ b/src/Accessors/Library.elm
@@ -18,7 +18,7 @@ import Accessors exposing (Relation, makeOneToN)
     get (foo << onEach << bar) listRecord
     -- returns [2, 3, 4] 
 
-    over (foo << onEach << bar) (+1) listRecord
+    over (foo << onEach << bar) ((+) 1) listRecord
     -- returns {foo = [{ bar = 3}, {bar = 4}, {bar = 5}] }
 -}
 onEach : Relation super sub wrap -> Relation (List super) sub (List wrap)
@@ -37,10 +37,10 @@ onEach = makeOneToN List.map List.map
     get (qux << try << bar) maybeRecord
     -- returns Nothing
 
-    over (foo << try << bar) (+1) maybeRecord
+    over (foo << try << bar) ((+) 1) maybeRecord
     -- returns { foo = Just { bar = 3} , qux = Nothing }
 
-    over (qux << try << bar) (+1) maybeRecord
+    over (qux << try << bar) ((+) 1) maybeRecord
     -- returns { foo = Just { bar = 2} , qux = Nothing }
 -}
 try : Relation super sub wrap -> Relation (Maybe super) sub (Maybe wrap)


### PR DESCRIPTION
Just a really minor change. I assume anyone who's using this package would be know the correct way, but figured it could be corrected anyway.