### PR TITLE
correct license, correct `makeOneToOne` example, use a consistent format

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ try =
 Accessors can be composed easily to describe relations:
 
 ```elm
-myData = {foo = [ {bar = 3}
-                , {bar = 2}
-                , {bar = 0}
-                ]
+myData = { foo = [ {bar = 3}
+                 , {bar = 2}
+                 , {bar = 0}
+                 ]
          }
 
 myAccessor = recordFoo << onEach << recordBar
@@ -65,10 +65,10 @@ getter   = get  myAccessor myData
   -- returns [3, 2, 0]
 
 setter   = set  myAccessor 2 myData
-  -- returns {foo = [{bar = 2}, {bar = 2}, {bar = 2}] }
+  -- returns {foo = [{bar = 2}, {bar = 2}, {bar = 2}]}
 
 transform = over myAccessor (\n -> n*2) myData
-  -- returns {foo = [{bar = 6}, {bar = 4}, {bar = 0}] }
+  -- returns {foo = [{bar = 6}, {bar = 4}, {bar = 0}]}
 ```
 
 # Type-safe and reusable
@@ -96,7 +96,7 @@ Any accessor you make can be composed with any other accessor to match your new
 data structures: 
 
 ```elm
-myOtherData = { bar = Just [1, 3, 2] }
+myOtherData = {bar = Just [1, 3, 2]}
 
 halfWay = try << onEach
 myOtherAccessor = recordBar << halfWay

--- a/elm-package.json
+++ b/elm-package.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "summary": "Accessors, a library implementing lenses for Elm.",
     "repository": "https://github.com/bChiquet/elm-accessors.git",
-    "license": "BSD-3-Clause",
+    "license": "MIT",
     "source-directories": [
         "src/"
     ],

--- a/elm.json
+++ b/elm.json
@@ -2,7 +2,7 @@
     "type": "package",
     "name": "bChiquet/elm-accessors",
     "summary": "Accessors, a library implementing lenses for Elm.",
-    "license": "BSD-3-Clause",
+    "license": "MIT",
     "version": "2.0.0",
     "exposed-modules": [
         "Accessors",

--- a/src/Accessors.elm
+++ b/src/Accessors.elm
@@ -103,8 +103,8 @@ over : (Relation sub sub sub -> Relation super sub wrap)
     -> super
     -> super
 over accessor change s = 
-  let (Relation relation) = (accessor id) in
-  relation.over change s
+  let (Relation relation) = (accessor id)
+  in relation.over change s
 
 
 {-| This function lets you build an accessor for containers that have
@@ -115,7 +115,7 @@ foo : Relation field sub wrap -> Relation {rec | foo : field} sub wrap
 foo =
   makeOneToOne
     .foo
-    \change rec -> {rec | foo = change rec.foo }
+    (\change rec -> {rec | foo = change rec.foo })
 ```
 -}
 makeOneToOne :  (super -> sub)

--- a/src/Accessors/Library.elm
+++ b/src/Accessors/Library.elm
@@ -9,7 +9,7 @@ import Accessors exposing (Relation, makeOneToN)
 
 {-| This accessor combinator lets you access values inside lists.
 
-    listRecord = {foo = [{ bar = 2}
+    listRecord = {foo = [ {bar = 2}
                         , {bar = 3}
                         , {bar = 4}
                         ]
@@ -19,7 +19,7 @@ import Accessors exposing (Relation, makeOneToN)
     -- returns [2, 3, 4] 
 
     over (foo << onEach << bar) ((+) 1) listRecord
-    -- returns {foo = [{ bar = 3}, {bar = 4}, {bar = 5}] }
+    -- returns {foo = [{bar = 3}, {bar = 4}, {bar = 5}] }
 -}
 onEach : Relation super sub wrap -> Relation (List super) sub (List wrap)
 onEach = makeOneToN List.map List.map
@@ -27,7 +27,7 @@ onEach = makeOneToN List.map List.map
 
 {-| This accessor combinator lets you access values inside Maybe.
 
-    maybeRecord = { foo = Just { bar = 2}
+    maybeRecord = { foo = Just {bar = 2}
                   , qux = Nothing
                   }
 
@@ -38,10 +38,10 @@ onEach = makeOneToN List.map List.map
     -- returns Nothing
 
     over (foo << try << bar) ((+) 1) maybeRecord
-    -- returns { foo = Just { bar = 3} , qux = Nothing }
+    -- returns {foo = Just {bar = 3}, qux = Nothing}
 
     over (qux << try << bar) ((+) 1) maybeRecord
-    -- returns { foo = Just { bar = 2} , qux = Nothing }
+    -- returns {foo = Just {bar = 2}, qux = Nothing}
 -}
 try : Relation super sub wrap -> Relation (Maybe super) sub (Maybe wrap)
 try = makeOneToN Maybe.map Maybe.map

--- a/src/Accessors/Library.elm
+++ b/src/Accessors/Library.elm
@@ -9,17 +9,17 @@ import Accessors exposing (Relation, makeOneToN)
 
 {-| This accessor combinator lets you access values inside lists.
 
-    listRecord = {foo = [ {bar = 2}
-                        , {bar = 3}
-                        , {bar = 4}
-                        ]
+    listRecord = { foo = [ {bar = 2}
+                         , {bar = 3}
+                         , {bar = 4}
+                         ]
                  }
 
     get (foo << onEach << bar) listRecord
     -- returns [2, 3, 4] 
 
     over (foo << onEach << bar) ((+) 1) listRecord
-    -- returns {foo = [{bar = 3}, {bar = 4}, {bar = 5}] }
+    -- returns {foo = [{bar = 3}, {bar = 4}, {bar = 5}]}
 -}
 onEach : Relation super sub wrap -> Relation (List super) sub (List wrap)
 onEach = makeOneToN List.map List.map


### PR DESCRIPTION
- correct license (fixes https://github.com/bChiquet/elm-accessors/issues/4)
  
  ```json
  - "license": "BSD-3-Clause",
  + "license": "MIT",
  ```

- correct `makeOneToOne` example

  ```elm
  makeOneToOne
    .foo
  - \change rec -> {rec | foo = change rec.foo }
  +(\change rec -> {rec | foo = change rec.foo })
  ```

- All examples now use a consistent format, for example
  
  ```elm
  - -- returns { foo = Just { bar = 3} , qux = Nothing }
  + -- returns {foo = Just {bar = 3}, qux = Nothing}
  ```

I'd honestly just format all examples using elm-format.
